### PR TITLE
Add GitHub Packages publishing workflow

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,0 +1,42 @@
+name: Publish Gem to GitHub Packages
+
+on:
+  push:
+    tags:
+      - "v*"
+      - "[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.5"
+          bundler-cache: true
+
+      - name: Build gem
+        run: gem build *.gemspec
+
+      - name: Configure gem credentials
+        run: |
+          mkdir -p ~/.gem
+          cat << EOF > ~/.gem/credentials
+          ---
+          :github: Bearer ${{ secrets.GITHUB_TOKEN }}
+          EOF
+          chmod 0600 ~/.gem/credentials
+
+      - name: Push to GitHub Packages
+        run: |
+          gem push --key github \
+            --host https://rubygems.pkg.github.com/customink \
+            *.gem

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg/*
 rdoc/*
+*.gem

--- a/moqueue.gemspec
+++ b/moqueue.gemspec
@@ -53,6 +53,9 @@ Gem::Specification.new do |s|
   ]
   s.homepage = "https://github.com/customink/moqueue"
   s.licenses = ["MIT"]
+
+  s.metadata["github_repo"] = "ssh://github.com/customink/moqueue"
+  s.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/customink"
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.17"
   s.summary = "Mocktacular Companion to AMQP Library. Happy TATFTing!"


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to publish gem to GitHub Packages on version tag push
- Add gemspec metadata for GitHub Packages compatibility
- Add `*.gem` to .gitignore
- Support both `v*` and plain semver tags (e.g., `0.3.0`)

## Usage

After merge, push a version tag to trigger automatic publishing:
```bash
git tag 0.3.1
git push origin 0.3.1
```

Or use workflow_dispatch to manually publish any version.